### PR TITLE
Add use_maven_local property

### DIFF
--- a/example-app/build.gradle
+++ b/example-app/build.gradle
@@ -34,6 +34,7 @@ final repoURL = "${repo_venture_tech_url}/${repo_venture_tech_key}"
 buildscript {
     final buildRepoURL = "${repo_venture_tech_url}/${repo_venture_tech_key}"
     repositories {
+        if(useMavenLocal){ mavenLocal() }
         if(hasLocalRepo){ maven { url = local_repo } }
         maven {
             credentials {
@@ -80,6 +81,7 @@ try{
 
 
 repositories {
+    if(useMavenLocal){ mavenLocal() }
     if(hasLocalRepo){ maven { url = local_repo } }
     maven {
         credentials {

--- a/example-app/settings.gradle
+++ b/example-app/settings.gradle
@@ -11,6 +11,7 @@ def props = [
 settings.gradle.projectsLoaded( {
     props.each({it.test(settings)})
     settings.gradle.rootProject.ext.hasLocalRepo = settings.hasProperty('local_repo');
+    settings.gradle.rootProject.ext.useMavenLocal = settings.hasProperty('use_maven_local') && settings.use_maven_local.toBoolean();
 })
 
 


### PR DESCRIPTION
If set to true in gradle.properties, artifacts in the local Maven repository will be used instead of downloading them. The expected workflow is to set this and override version_proteus in gradle.properties to the development version (e.g. 0.7.0 as of this writing), then build Proteus using `./gradlew install` to install it in the local repo. You can then build your application using `./gradlew war` and deploy it.

https://docs.google.com/a/vipasolutions.com/document/d/1Y4Xfn_d3XyrgyXscVDcwcbGRXMPcSN2xyOmfneUAttg/edit
